### PR TITLE
[함진규] 세번째 PR

### DIFF
--- a/coffee/src/main/java/com/cnu/coffee/order/Order.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/Order.java
@@ -1,0 +1,26 @@
+package com.cnu.coffee.order;
+
+import lombok.Data;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "orders")
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(nullable = false, length = 120, unique = true)
+    private String orderId;
+    @Lob
+    private String memo;
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+    @Column(nullable = false, updatable = false, insertable = false)
+    @ColumnDefault(value = "CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/OrderController.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/OrderController.java
@@ -1,0 +1,40 @@
+package com.cnu.coffee.order;
+
+import com.cnu.coffee.product.RequestProductDto;
+import com.cnu.coffee.product.ResponseProductDto;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class OrderController {
+
+    OrderService orderService;
+
+    @Autowired
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping("/orders")
+    public ResponseEntity<ResponseOrderDto> createOrder(@RequestBody RequestOrderDto requestOrderDto) {
+        orderService.createOrder(requestOrderDto);
+
+        ResponseOrderDto responseOrderDto = new ResponseOrderDto();
+        BeanUtils.copyProperties(requestOrderDto, responseOrderDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseOrderDto);
+    }
+
+    @GetMapping("/orders")
+    public ResponseEntity<List<ResponseOrderDto>> getAllOrders() {
+        return ResponseEntity.status(HttpStatus.OK).body(orderService.getOrderByAll());
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/OrderRepository.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/OrderRepository.java
@@ -1,0 +1,6 @@
+package com.cnu.coffee.order;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/OrderService.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/OrderService.java
@@ -1,0 +1,42 @@
+package com.cnu.coffee.order;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class OrderService {
+    OrderRepository orderRepository;
+
+    @Autowired
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    public Order createOrder(RequestOrderDto requestOrderDto) {
+        requestOrderDto.setOrderId(UUID.randomUUID().toString());
+
+        Order order = new Order();
+        BeanUtils.copyProperties(requestOrderDto, order);
+
+        return orderRepository.save(order);
+    }
+
+
+    public List<ResponseOrderDto> getOrderByAll() {
+        List<Order> orderList = orderRepository.findAll();
+
+        List<ResponseOrderDto> result = new ArrayList<>();
+        orderList.forEach(v -> {
+            ResponseOrderDto responseOrderDto = new ResponseOrderDto();
+            BeanUtils.copyProperties(v, responseOrderDto);
+            result.add(responseOrderDto);
+        });
+
+        return result;
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/OrderStatus.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.cnu.coffee.order;
+
+public enum OrderStatus {
+    OPENED, CANCELLED
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/RequestOrderDto.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/RequestOrderDto.java
@@ -1,0 +1,16 @@
+package com.cnu.coffee.order;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Data
+public class RequestOrderDto {
+    private String orderId;
+    private String memo;
+    @NotNull(message = "OrderStatus cannot be null")
+    private OrderStatus orderStatus;
+    @NotNull(message = "Price cannot be null")
+    private LocalDateTime createdAt;
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/ResponseOrderDto.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/ResponseOrderDto.java
@@ -1,0 +1,7 @@
+package com.cnu.coffee.order;
+
+public class ResponseOrderDto {
+    private String orderId;
+    private String memo;
+    private OrderStatus orderStatus;
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/Category.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/Category.java
@@ -1,0 +1,5 @@
+package com.cnu.coffee.product;
+
+public enum Category {
+    COFFEBEAN_BEAN_PACKAGE
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/Product.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/Product.java
@@ -1,0 +1,30 @@
+package com.cnu.coffee.product;
+
+import lombok.Data;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "products")
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 120, unique = true)
+    private String productId;
+    @Column(nullable = false)
+    private String name;
+    @Enumerated(EnumType.STRING)
+    private Category category;
+    @Column(nullable = false)
+    private long price;
+    private String description;
+    @Column(nullable = false, updatable = false, insertable = false)
+    @ColumnDefault(value = "CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/ProductController.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/ProductController.java
@@ -1,0 +1,40 @@
+package com.cnu.coffee.product;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class ProductController {
+
+    ProductService productService;
+
+    @Autowired
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @PostMapping("/products")
+    public ResponseEntity<ResponseProductDto> createProduct(@RequestBody RequestProductDto requestProductDto) {
+        productService.createProduct(requestProductDto);
+
+        ResponseProductDto responseProductDto = new ResponseProductDto();
+        BeanUtils.copyProperties(requestProductDto, responseProductDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseProductDto);
+    }
+
+    @GetMapping("/products")
+    public ResponseEntity<List<ResponseProductDto>> getAllProducts() {
+        return ResponseEntity.status(HttpStatus.OK).body(productService.getProductByAll());
+    }
+
+    @RequestMapping(value = "/search")
+    public ResponseEntity<List<ResponseProductDto>> searchProduct(@RequestParam("name") String name) {
+        return ResponseEntity.status(HttpStatus.OK).body(productService.getProductByName(name));
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/ProductRepository.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/ProductRepository.java
@@ -1,0 +1,11 @@
+package com.cnu.coffee.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByNameContaining(String name);
+
+    Product findByProductId(String productId);
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/ProductService.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/ProductService.java
@@ -1,0 +1,63 @@
+package com.cnu.coffee.product;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ProductService {
+    ProductRepository productRepository;
+
+    @Autowired
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public Product createProduct(RequestProductDto requestProductDto) {
+        requestProductDto.setProductId(UUID.randomUUID().toString());
+
+        Product product = new Product();
+        BeanUtils.copyProperties(requestProductDto, product);
+
+        return productRepository.save(product);
+    }
+
+    public List<ResponseProductDto> getProductByAll() {
+        List<Product> productList = productRepository.findAll();
+
+        List<ResponseProductDto> result = new ArrayList<>();
+        productList.forEach(v -> {
+            ResponseProductDto responseProductDto = new ResponseProductDto();
+            BeanUtils.copyProperties(v, responseProductDto);
+            result.add(responseProductDto);
+        });
+
+        return  result;
+    }
+
+    public ResponseProductDto getProductById(String productId) {
+        Product product = productRepository.findByProductId(productId);
+
+        ResponseProductDto responseProductDto = new ResponseProductDto();
+        BeanUtils.copyProperties(product, responseProductDto);
+
+        return responseProductDto;
+    }
+
+    public List<ResponseProductDto> getProductByName(String name) {
+        List<Product> productList = productRepository.findByNameContaining(name);
+
+        List<ResponseProductDto> result = new ArrayList<>();
+        productList.forEach(v -> {
+            ResponseProductDto responseProductDto = new ResponseProductDto();
+            BeanUtils.copyProperties(v, responseProductDto);
+            result.add(responseProductDto);
+        });
+
+        return result;
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/RequestProductDto.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/RequestProductDto.java
@@ -1,0 +1,20 @@
+package com.cnu.coffee.product;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Data
+public class RequestProductDto {
+    private String productId;
+    @NotNull(message = "Product Name cannot be null")
+    private String name;
+    @NotNull(message = "Category cannot be null")
+    private Category category;
+    @NotNull(message = "Price cannot be null")
+    private long price;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/coffee/src/main/java/com/cnu/coffee/product/ResponseProductDto.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/ResponseProductDto.java
@@ -1,0 +1,11 @@
+package com.cnu.coffee.product;
+
+import lombok.Data;
+
+@Data
+public class ResponseProductDto {
+    private String name;
+    private Category category;
+    private long price;
+    private String description;
+}

--- a/coffee/src/test/java/com/cnu/coffee/product/ProductServiceTest.java
+++ b/coffee/src/test/java/com/cnu/coffee/product/ProductServiceTest.java
@@ -1,0 +1,40 @@
+package com.cnu.coffee.product;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+class ProductServiceTest {
+
+    @Autowired
+    ProductService productService;
+    @Autowired
+    ProductRepository productRepository;
+
+    @Test
+    @DisplayName("상품 생성 테스트")
+    public void testCreateProduct() {
+        RequestProductDto requestProductDto = new RequestProductDto();
+        requestProductDto.setProductId(UUID.randomUUID().toString());
+        requestProductDto.setName("aaa");
+        requestProductDto.setCategory(Category.COFFEBEAN_BEAN_PACKAGE);
+        requestProductDto.setPrice(1000L);
+        requestProductDto.setDescription("bbb");
+
+        productService.createProduct(requestProductDto);
+
+        Product retrievedProduct = productRepository.findByProductId(requestProductDto.getProductId());
+        log.info("created at : {}", retrievedProduct.getCreatedAt());
+        assertEquals(requestProductDto.getName(), retrievedProduct.getName());
+    }
+}


### PR DESCRIPTION
상품 레포지터리를 CrudRepository에서 JpaRepository로 변경합니다.
ProductDto와 RequestProduct(VO)를 하나로 합친 RequestProductDto를 사용합니다. 테스트 코드를 추가합니다.

### 구현내용

1.  상품 레포지터리를 CrudRepository에서 JpaRepository로 변경
2. RequestProductDto
ProductDto와 RequestProduct(VO)를 하나로 합친 RequestProductDto를 사용합니다.
3. 주문 도메인 구현 
상품 도메인을 구현한 것과 동일하게 주문 추가, 주문 전체 조회가 가능합니다.
주문 엔티티는 주문ID, 메모, 주문날짜 필드를 가집니다.

### 궁금한점

1. 상품 리뷰의 위치
~~주문과 상품은 다대다 관계인데, 이를 어떻게 풀어야할지 잘 모르겠습니다.~~